### PR TITLE
feat: AsyncIterator for streaming prompts

### DIFF
--- a/end-to-end/static/index.html
+++ b/end-to-end/static/index.html
@@ -191,9 +191,14 @@
       userInput.value = '';
 
       try {
-        const response = await window.electronAi.prompt(message);
-        messagesContainer.appendChild(createMessageElement(response, 'model'));
-        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        const modelMessage = createMessageElement('', 'model');
+        messagesContainer.appendChild(modelMessage);
+
+        const stream = await window.electronAi.promptStreaming(message);
+        for await (const chunk of stream) {
+          modelMessage.textContent = 'Model: ' + (modelMessage.textContent.slice(7) + chunk);
+          messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
       } catch (error) {
         console.error('Error getting response:', error);
         alert(`Error getting response: ${error.message}`);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,7 +17,7 @@ export interface ElectronLlmRenderer {
   promptStreaming: (
     input: string,
     options?: LanguageModelPromptOptions,
-  ) => Promise<string>;
+  ) => Promise<AsyncIterableIterator<string>>;
 }
 
 // Main interfaces

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -17,7 +17,7 @@ export enum LanguageModelPromptType {
 
 type LanguageModelPromptContent = string | ArrayBuffer;
 
-interface LanguageModelPrompt {
+export interface LanguageModelPrompt {
   role: LanguageModelPromptRole;
   type: LanguageModelPromptType;
   content: LanguageModelPromptContent;


### PR DESCRIPTION
This PR ensures that the renderer and utility process establish a direct messageport connection, allowing us to stream responses to the renderer chunk-by-chunk. It also makes sure that `promptStreaming()` returns an `AsyncIterable()` (just like our model `window.ai` does). 

This keeps the main process happy _and_ allows the typical "token by token" UX that's so hot right now.