### PR TITLE
feat: Load models by naming an alias in the renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Loads the LLM module in the main process.
 
 - `options`: Optional configuration
   - `isAutomaticPreloadDisabled`: If true, the automatic preload script injection is disabled
+  - `getModelPath`: A function that takes a model alias and returns the full path to the GGUF model file. By default, this function returns a path in the app's userData directory: `path.join(app.getPath('userData'), 'models', modelAlias)`. You can override this to customize where models are stored.
 
 ### Renderer Process API
 
@@ -71,7 +72,7 @@ The renderer process API is exposed via `window.electronAi` once loaded via prel
 Creates and initializes a language model instance. This module will at most create one utility process with one model loaded. If you call `create` multiple times, it will return the existing instance. If you call it with new (not deep equal) options, it will stop and unload previously loaded models and load the model defined in the new options.
 
 - `options`: Configuration for the language model
-  - `modelPath`: Path to the GGUF model file
+  - `modelAlias`: Name of the model you want to load. Will be passed to `getModelPath()`.
   - `systemPrompt`: Optional system prompt to initialize the model
   - `initialPrompts`: Optional array of initial prompts to provide context
   - `topK`: Optional parameter to control diversity of generated text

--- a/__tests__/preload.test.ts
+++ b/__tests__/preload.test.ts
@@ -33,7 +33,7 @@ describe('Preload Interface', () => {
   });
 
   it('create should invoke with correct ipcMessage and options', async () => {
-    const options = { modelPath: 'dummy-model.gguf' };
+    const options = { modelAlias: 'dummy-model' };
     await (globalThis as any).electronAi.create(options);
     expect(ipcRenderer.invoke).toHaveBeenCalledWith(
       IpcRendererMessage.ELECTRON_LLM_CREATE,
@@ -95,11 +95,6 @@ describe('Preload Interface', () => {
         } as MessageEvent);
       }
     });
-
-    // Create a promise that resolves after a short delay to allow the iterator to be returned
-    const streamingPromise = (globalThis as any).electronAi.promptStreaming(
-      input,
-    );
 
     await (globalThis as any).electronAi.promptStreaming(input);
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface ElectronLlmMain {}
 
 export type MainLoadOptions = {
   isAutomaticPreloadDisabled?: boolean;
+  getModelPath?: GetModelPathFunction;
 };
 
 export type LoadOptions = MainLoadOptions;
@@ -32,3 +33,7 @@ export type ElectronAi = ElectronLlmRenderer;
 
 export type MainLoadFunction = (options?: LoadOptions) => Promise<void>;
 export type RendererLoadFunction = () => Promise<void>;
+
+export type GetModelPathFunction = (
+  modelAlias: string,
+) => Promise<string> | string;

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -29,6 +29,11 @@ export interface LanguageModelCreateOptions {
   topK?: number;
   temperature?: number;
   signal?: AbortSignal;
+  modelAlias: string;
+}
+
+export interface InternalLanguageModelCreateOptions
+  extends LanguageModelCreateOptions {
   modelPath: string;
 }
 
@@ -90,7 +95,7 @@ export class LanguageModel {
   }
 
   static async create(
-    options: LanguageModelCreateOptions,
+    options: InternalLanguageModelCreateOptions,
   ): Promise<LanguageModel> {
     try {
       const llamaCpp = await getLlamaCpp();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { session, app, BrowserWindow } from 'electron';
 import path from 'node:path';
 
-import { MainLoadFunction } from '../interfaces.js';
+import { GetModelPathFunction, MainLoadFunction } from '../interfaces.js';
 import { registerAiHandlers } from './register-ai-handlers.js';
 
 export const loadElectronLlm: MainLoadFunction = async (options) => {
@@ -20,8 +20,14 @@ export const loadElectronLlm: MainLoadFunction = async (options) => {
     });
   }
 
+  const getModelPath: GetModelPathFunction =
+    options?.getModelPath ||
+    ((modelAlias: string) => {
+      return path.join(app.getPath('userData'), 'models', modelAlias);
+    });
+
   // Register handler
-  registerAiHandlers();
+  registerAiHandlers({ getModelPath });
 };
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,10 +19,10 @@ function validateCreateOptions(options?: LanguageModelCreateOptions): void {
   if (!options) return;
 
   if (
-    options.modelPath === undefined ||
-    typeof options.modelPath !== 'string'
+    options.modelAlias === undefined ||
+    typeof options.modelAlias !== 'string'
   ) {
-    throw new TypeError('modelPath is required and must be a string');
+    throw new TypeError('modelAlias is required and must be a string');
   }
 
   if (

--- a/src/utility/call-ai-model-entry-point.ts
+++ b/src/utility/call-ai-model-entry-point.ts
@@ -4,14 +4,14 @@ import {
   LanguageModelPromptRole,
   LanguageModelPromptType,
   LanguageModelPromptOptions,
-  LanguageModelCreateOptions,
   LanguageModelPrompt,
+  InternalLanguageModelCreateOptions,
 } from '../language-model.js';
 import { UTILITY_MESSAGE_TYPES } from './messages.js';
 
 let languageModel: LanguageModel;
 
-async function loadModel(options: LanguageModelCreateOptions) {
+async function loadModel(options: InternalLanguageModelCreateOptions) {
   try {
     languageModel = await LanguageModel.create(options);
   } catch (error) {


### PR DESCRIPTION
Right now, the renderer passes a direct model path to the main process. With this change, the renderer passes an alias, which the main process then turns into a proper path.