### PR TITLE
fix: prevent path escape in model alias based loading

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,4 +36,4 @@ export type RendererLoadFunction = () => Promise<void>;
 
 export type GetModelPathFunction = (
   modelAlias: string,
-) => Promise<string> | string;
+) => Promise<string | null> | string | null;

--- a/src/main/register-ai-handlers.ts
+++ b/src/main/register-ai-handlers.ts
@@ -35,6 +35,13 @@ export function registerAiHandlers({
         return;
       }
 
+      const modelPath = await getModelPath(options.modelAlias);
+      if (!modelPath) {
+        throw new Error(
+          `Model path not found for alias: ${options.modelAlias}. Please provide a valid model path.`,
+        );
+      }
+
       aiProcessCreationOptions = options;
 
       if (aiProcess) {
@@ -55,7 +62,7 @@ export function registerAiHandlers({
         type: UTILITY_MESSAGE_TYPES.LOAD_MODEL,
         data: {
           ...options,
-          modelPath: await getModelPath(options.modelAlias),
+          modelPath,
         },
       });
 


### PR DESCRIPTION
Stops any sneaky renderers from loading models outside of the models directory