### PR TITLE
fix: fixup initial release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # @electron/llm
 
+[![Test](https://github.com/electron/llm/actions/workflows/test.yml/badge.svg)](https://github.com/electron/llm/actions/workflows/test.yml)
+[![npm version](https://img.shields.io/npm/v/@electron/llm.svg)](https://npmjs.org/package/@electron/llm)
+
 This module makes it easy for developers to prototype local-first applications interacting with local large language models (LLMs), especially in chat contexts.
 
 It aims for an API surface similar to Chromium's `window.AI` API, except that you can supply any GGUF model. Under the hood, `@electron/llm` makes use of [node-llama-cpp](https://github.com/withcatai/node-llama-cpp). Our goal is to make use of native LLM capabilities in Electron _easier_ than if you consumed a Llama.cpp implementation directly - but not more feature-rich. Today, this module provides a reference implementation of `node-llama-cpp` that loads the model in a utility process and uses Chromium Mojo IPC pipes to efficiently facilitate streaming of responses between the utility process and renderers. If you're building an advanced app with LLM, you might want to use this module as a reference for your process architecture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@electron/llm",
-  "version": "0.1.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@electron/llm",
-      "version": "0.1.0",
+      "version": "0.0.0-development",
       "license": "MIT",
       "workspaces": [
         "end-to-end"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "workspaces": [
     "end-to-end"
   ],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "publishConfig": {
     "provenance": true
   },
@@ -36,7 +40,8 @@
     "test:e2e:tsc": "tsc -p end-to-end/tsconfig.json",
     "test:e2e:rebuild": "electron-rebuild",
     "test:e2e:run": "electron end-to-end/dist/main.js",
-    "prepare": "husky install"
+    "prepublishOnly": "npm run tsc",
+    "prepare": "husky"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
The v1.0.0 release went out but doesn't include `dist/` so it's not a usable release. This fixes that plus a couple other improvements.