### PR TITLE
fix: Don't fake a successful load on retry

### DIFF
--- a/src/main/register-ai-handlers.ts
+++ b/src/main/register-ai-handlers.ts
@@ -81,6 +81,15 @@ export function registerAiHandlers({
       if (type === UTILITY_MESSAGE_TYPES.MODEL_LOADED) {
         return;
       } else if (type === UTILITY_MESSAGE_TYPES.ERROR) {
+        // Try to clean up
+        try {
+          await stopModel();
+        } catch (error) {
+          console.error(
+            `Failed to stop AI model process after error: ${(error as Error).message || 'Unknown error'}`,
+          );
+        }
+
         throw new Error(responseData);
       } else {
         throw new Error(`Unexpected message type: ${type}`);
@@ -246,7 +255,7 @@ async function stopModel(): Promise<void> {
 }
 
 function shouldStartNewAiProcess(options: LanguageModelCreateOptions): boolean {
-  if (!aiProcess || !aiProcessCreationOptions) {
+  if (!aiProcess || !aiProcess.pid || !aiProcessCreationOptions) {
     return true;
   }
 

--- a/src/utility/call-ai-model-entry-point.ts
+++ b/src/utility/call-ai-model-entry-point.ts
@@ -109,7 +109,7 @@ function stopModel() {
     data: 'Model session reset.',
   });
 
-  process.parentPort.emit('exit');
+  process.exit(0);
 }
 
 process.parentPort.on('message', async (messageEvent) => {


### PR DESCRIPTION
Calling `load()` after an error will always succeed - but only because we don't actually try again. This fixes that.