### PR TITLE
ci: timeout release job after 1 hour

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install
         run: npm ci
       - uses: continuousauth/action@4e8a2573eeb706f6d7300d6a9f3ca6322740b72d # v1.0.5
+        timeout-minutes: 60
         with:
           project-id: ${{ secrets.CFA_PROJECT_ID }}
           secret: ${{ secrets.CFA_SECRET }}


### PR DESCRIPTION
The GH token acquired during the `continuousauth/action` step is only good for 1 hour, and if a maintainer provides a CFA token after that time we end up with the npm publish going through but none of the follow-up steps on GitHub (creating the release, commenting on PRs, etc).